### PR TITLE
feat: restore create nuki credential draft interactor

### DIFF
--- a/web-api/src/Kerbero.Domain/Common/Repositories/KerberoConfigurationRepository.cs
+++ b/web-api/src/Kerbero.Domain/Common/Repositories/KerberoConfigurationRepository.cs
@@ -1,0 +1,9 @@
+using FluentResults;
+using Kerbero.Domain.NukiCredentials.Models;
+
+namespace Kerbero.Domain.Common.Interfaces;
+
+public interface IKerberoConfigurationRepository
+{
+  Task<Result<NukiApiConfigurationModel>> GetApiDefinition();
+}

--- a/web-api/src/Kerbero.Domain/NukiCredentials/Interactors/CreateNukiCredentialDraftInteractor.cs
+++ b/web-api/src/Kerbero.Domain/NukiCredentials/Interactors/CreateNukiCredentialDraftInteractor.cs
@@ -1,0 +1,58 @@
+using FluentResults;
+using Kerbero.Domain.Common.Interfaces;
+using Kerbero.Domain.NukiCredentials.Interfaces;
+using Kerbero.Domain.NukiCredentials.Models;
+using Kerbero.Domain.NukiCredentials.Repositories;
+
+namespace Kerbero.Domain.NukiCredentials.Interactors;
+
+/// <summary>
+/// Nuki Web platform authentication flow:
+/// Kerbero User, authenticated on Kerbero
+/// -> Redirect to Nuki website
+/// -> User accepts / allows Kerbero Nuki app to act in his behalf
+/// -> Nuki  website calls Kerbero API 
+///
+/// In the last step of the flow, we do not know which Kerbero user initiated the flow, since Nuki website calls us
+/// without any authentication.
+///
+/// This interactor solves this problem by creating a draft of the user Nuki Credentials, that will be confirmed when
+/// Nuki Web redirects the user to us with a matching uri (<see cref="NukiCredentialDraftModel.GetOAuthRedirectUri"/>
+/// </summary>
+public class CreateNukiCredentialDraftInteractor : ICreateNukiCredentialDraftInteractor
+{
+  private readonly INukiCredentialRepository _nukiCredentialRepository;
+  private readonly IKerberoConfigurationRepository _kerberoConfigurationRepository;
+
+  public CreateNukiCredentialDraftInteractor(INukiCredentialRepository nukiCredentialRepository, IKerberoConfigurationRepository kerberoConfigurationRepository)
+  {
+    _nukiCredentialRepository = nukiCredentialRepository;
+    _kerberoConfigurationRepository = kerberoConfigurationRepository;
+  }
+
+  public async Task<Result<NukiCredentialDraftModel>> Handle(string clientId, Guid userId)
+  {
+    var nukiApiDefinitionResult = await _kerberoConfigurationRepository.GetApiDefinition();
+    
+    if (nukiApiDefinitionResult.IsFailed)
+    {
+      return Result.Fail(nukiApiDefinitionResult.Errors);
+    }
+    
+    var redirectUri = NukiCredentialDraftModel.GetOAuthRedirectUri(nukiApiDefinitionResult.Value);
+    
+    var nukiCredentialDraft = new NukiCredentialDraftModel(
+      UserId: userId,
+      RedirectUrl: redirectUri.ToString()
+    );
+
+    var createResult = await _nukiCredentialRepository.CreateDraft(nukiCredentialDraft);
+
+    if (createResult.IsFailed)
+    {
+      return Result.Fail(createResult.Errors);
+    }
+
+    return nukiCredentialDraft;
+  }
+}

--- a/web-api/src/Kerbero.Domain/NukiCredentials/Interfaces/ICreateNukiCredentialDraftInteractor.cs
+++ b/web-api/src/Kerbero.Domain/NukiCredentials/Interfaces/ICreateNukiCredentialDraftInteractor.cs
@@ -1,0 +1,9 @@
+using FluentResults;
+using Kerbero.Domain.NukiCredentials.Models;
+
+namespace Kerbero.Domain.NukiCredentials.Interfaces;
+
+public interface ICreateNukiCredentialDraftInteractor
+{
+  Task<Result<NukiCredentialDraftModel>> Handle(string clientId, Guid userId);
+}

--- a/web-api/src/Kerbero.Domain/NukiCredentials/Models/NukiApiConfigurationModel.cs
+++ b/web-api/src/Kerbero.Domain/NukiCredentials/Models/NukiApiConfigurationModel.cs
@@ -1,0 +1,17 @@
+namespace Kerbero.Domain.NukiCredentials.Models;
+
+/// <summary>
+/// Represents information about nuki params configuration
+/// </summary>
+/// <param name="apiEndpoint">Complete uri for the base nuki api</param>
+/// <param name="clientId">Client id of our app registered inside nuki web account</param>
+/// <param name="scopes">Which scopes should be requested for the user nuki account</param>
+/// <param name="applicationRedirectEndpoint">The endpoint that will handle the user redirection after he grants us the requested scopes</param>
+/// <param name="applicationDomain">The domain where the Kerbero application is served</param>
+public record NukiApiConfigurationModel(
+  string apiEndpoint,
+  string clientId,
+  string scopes,
+  string applicationRedirectEndpoint,
+  string applicationDomain
+);

--- a/web-api/src/Kerbero.Domain/NukiCredentials/Models/NukiCredentialDraftModel.cs
+++ b/web-api/src/Kerbero.Domain/NukiCredentials/Models/NukiCredentialDraftModel.cs
@@ -1,0 +1,31 @@
+using System.Text.Encodings.Web;
+using System.Web;
+
+namespace Kerbero.Domain.NukiCredentials.Models;
+
+/// <summary>
+/// Represents a nuki credential that will be confirmed later on after a Nuki Authentication process
+/// </summary>
+public record NukiCredentialDraftModel(string RedirectUrl, Guid UserId)
+{
+  /// <summary>
+  /// Builds a correct URI to redirect our users to the Nuki Web platform in order to initiate a Nuki Authentication flow
+  /// </summary>
+  /// <param name="model"></param>
+  /// <returns></returns>
+  public static Uri GetOAuthRedirectUri(NukiApiConfigurationModel model)
+  {
+    var baseUri = $"{model.apiEndpoint}/oauth/authorize";
+    var applicationRedirectUri = $"{model.applicationDomain}/{model.applicationRedirectEndpoint}/{Guid.NewGuid()}";
+    
+    var queryParams = new List<string>()
+    {
+      "response_type=code",
+      $"client_id={model.clientId}",
+      $"scope={HttpUtility.UrlEncode(model.scopes)}",
+      $"redirect_uri={HttpUtility.UrlEncode(applicationRedirectUri)}",
+    };
+
+    return new UriBuilder(baseUri) { Query = string.Join("&", queryParams) }.Uri;
+  }
+}

--- a/web-api/src/Kerbero.Domain/NukiCredentials/Repositories/INukiCredentialRepository.cs
+++ b/web-api/src/Kerbero.Domain/NukiCredentials/Repositories/INukiCredentialRepository.cs
@@ -6,6 +6,8 @@ namespace Kerbero.Domain.NukiCredentials.Repositories;
 public interface INukiCredentialRepository
 {
   Task<Result<NukiCredentialModel>> Create(NukiCredentialModel model, Guid userId);
+
+  Task<Result<NukiCredentialModel>> CreateDraft(NukiCredentialDraftModel model);
   Task<Result<NukiCredentialModel>> GetById(int id);
   Task<Result<List<NukiCredentialModel>>> GetAllByUserId(Guid userId);
   Task<Result> ValidateApiToken(string apiToken);

--- a/web-api/src/Kerbero.Infrastructure/NukiCredentials/Repositories/NukiCredentialRepository.cs
+++ b/web-api/src/Kerbero.Infrastructure/NukiCredentials/Repositories/NukiCredentialRepository.cs
@@ -79,6 +79,11 @@ public class NukiCredentialRepository : INukiCredentialRepository
     }
   }
 
+  public Task<Result<NukiCredentialModel>> CreateDraft(NukiCredentialDraftModel model)
+  {
+    throw new NotImplementedException();
+  }
+
   public async Task<Result<NukiCredentialModel>> GetById(int id)
   {
     try

--- a/web-api/src/Kerbero.WebApi/.env-example
+++ b/web-api/src/Kerbero.WebApi/.env-example
@@ -2,7 +2,14 @@
 
 # Nuki API options
 
+ALIAS_DOMAIN=https://test.com:5220
+
+# Nuki API options
+
+NUKI_REDIRECT_FOR_TOKEN=/api/nuki/auth/token
+NUKI_SCOPES="account notification smartlock smartlock.readOnly smartlock.action smartlock.auth smartlock.config smartlock.log"
 NUKI_DOMAIN=https://api.nuki.io
+NUKI_CLIENT_SECRET=NUKI_CLIENT_SECRET
 
 # SendGrid options
 

--- a/web-api/tests/Kerbero.Domain.Tests/NukiCredentials/Models/NukiCredentialDraftModelTests.cs
+++ b/web-api/tests/Kerbero.Domain.Tests/NukiCredentials/Models/NukiCredentialDraftModelTests.cs
@@ -1,0 +1,29 @@
+using System.Web;
+using FluentAssertions;
+using Kerbero.Domain.NukiCredentials.Models;
+
+namespace Kerbero.Domain.Tests.NukiCredentials.Models;
+
+public class NukiCredentialDraftModelTests
+{
+  [Fact]
+  void It_Creates_A_Correct_Uri()
+  {
+    var uri = NukiCredentialDraftModel.GetOAuthRedirectUri(new NukiApiConfigurationModel(
+      apiEndpoint: "https://api.nuki.io",
+      clientId: "0",
+      scopes: "account notification",
+      applicationDomain: "https://test.domain",
+      applicationRedirectEndpoint: "api/nuki-credentials/confirm-draft"
+    ));
+
+    var partialUri =
+      $"https://api.nuki.io/oauth/authorize?response_type=code&client_id=0&scope={HttpUtility.UrlEncode("account notification")}&redirect_uri={HttpUtility.UrlEncode("https://test.domain/api/nuki-credentials/confirm-draft")}";
+    uri.ToString().Should().Contain(partialUri);
+
+    var rawGuid = uri.ToString().Replace(partialUri, "");
+    var validGuid = HttpUtility.UrlDecode(rawGuid).Remove(0, 1); // Drop the "/" between kerbero api endpoint and the guid
+    Guid.TryParse(validGuid, out var parsedGuid);
+    parsedGuid.Should().NotBeEmpty();
+  }
+}


### PR DESCRIPTION
Re-expose the possibility to create a _draft_ of `NukiCredentials`
```c#
    var interactorResponse = await _createNukiCredentialDraft.Handle(userId);

    if (interactorResponse.IsFailed)
    {
      var error = interactorResponse.Errors.First();
      return ModelState.AddErrorAndReturnAction(error);
    }
```