### PR TITLE
feat: build nuki redirect uri interactor

### DIFF
--- a/web-api/src/Kerbero.Domain/Common/Repositories/IKerberoConfigurationRepository.cs
+++ b/web-api/src/Kerbero.Domain/Common/Repositories/IKerberoConfigurationRepository.cs
@@ -1,0 +1,12 @@
+using Kerbero.Domain.NukiCredentials.Models;
+using FluentResults;
+
+namespace Kerbero.Domain.Common.Repositories;
+
+/// <summary>
+/// The role of this repository is bridge any env / json / ... configuration over to domain 
+/// </summary>
+public interface IKerberoConfigurationRepository
+{
+  Task<Result<NukiApiConfigurationModel>> GetNukiApiDefinition();
+}

--- a/web-api/src/Kerbero.Domain/NukiCredentials/Interactors/BuildNukiRedirectUriInteractor.cs
+++ b/web-api/src/Kerbero.Domain/NukiCredentials/Interactors/BuildNukiRedirectUriInteractor.cs
@@ -1,0 +1,45 @@
+using System.Web;
+using FluentResults;
+using Kerbero.Domain.Common.Repositories;
+using Kerbero.Domain.NukiCredentials.Interfaces;
+
+namespace Kerbero.Domain.NukiCredentials.Interactors;
+
+/// <summary>
+/// Builds a correct URI to redirect our users to the Nuki Web platform in order to initiate a Nuki Authentication flow
+/// </summary>
+public class BuildNukiRedirectUriInteractor : IBuildNukiRedirectUriInteractor
+{
+  private readonly IKerberoConfigurationRepository _kerberoConfigurationRepository;
+
+  public BuildNukiRedirectUriInteractor(IKerberoConfigurationRepository kerberoConfigurationRepository)
+  {
+    _kerberoConfigurationRepository = kerberoConfigurationRepository;
+  }
+
+  public async Task<Result<Uri>> Handle()
+  {
+    var nukiApiDefinitionResult = await _kerberoConfigurationRepository.GetNukiApiDefinition();
+
+    if (nukiApiDefinitionResult.IsFailed)
+    {
+      return Result.Fail(nukiApiDefinitionResult.Errors);
+    }
+
+    var nukiApiDefinition = nukiApiDefinitionResult.Value;
+
+    var baseUri = $"{nukiApiDefinition.ApiEndpoint}/oauth/authorize";
+    var applicationRedirectUri =
+      $"{nukiApiDefinition.ApplicationDomain}/{nukiApiDefinition.ApplicationRedirectEndpoint}";
+
+    var queryParams = new List<string>()
+    {
+      "response_type=code",
+      $"client_id={nukiApiDefinition.ClientId}",
+      $"scope={HttpUtility.UrlEncode(nukiApiDefinition.Scopes)}",
+      $"redirect_uri={HttpUtility.UrlEncode(applicationRedirectUri)}",
+    };
+
+    return new UriBuilder(baseUri) { Query = string.Join("&", queryParams) }.Uri;
+  }
+}

--- a/web-api/src/Kerbero.Domain/NukiCredentials/Interfaces/IBuildNukiRedirectUriInteractor.cs
+++ b/web-api/src/Kerbero.Domain/NukiCredentials/Interfaces/IBuildNukiRedirectUriInteractor.cs
@@ -1,0 +1,8 @@
+using FluentResults;
+
+namespace Kerbero.Domain.NukiCredentials.Interfaces;
+
+public interface IBuildNukiRedirectUriInteractor
+{
+  Task<Result<Uri>> Handle();
+}

--- a/web-api/src/Kerbero.Domain/NukiCredentials/Models/NukiApiConfigurationModel.cs
+++ b/web-api/src/Kerbero.Domain/NukiCredentials/Models/NukiApiConfigurationModel.cs
@@ -1,0 +1,17 @@
+namespace Kerbero.Domain.NukiCredentials.Models;
+
+/// <summary>
+/// Represents information about nuki params configuration
+/// </summary>
+/// <param name="ApiEndpoint">Complete uri for the base nuki api</param>
+/// <param name="ClientId">Client id of our app registered inside nuki web account</param>
+/// <param name="Scopes">Which scopes should be requested for the user nuki account</param>
+/// <param name="ApplicationRedirectEndpoint">The endpoint that will handle the user redirection after he grants us the requested scopes</param>
+/// <param name="ApplicationDomain">The domain where the Kerbero application is served</param>
+public record NukiApiConfigurationModel(
+  string ApiEndpoint,
+  string ClientId,
+  string Scopes,
+  string ApplicationRedirectEndpoint,
+  string ApplicationDomain
+);

--- a/web-api/tests/Kerbero.Domain.Tests/NukiCredentials/Interactors/BuildNukiRedirectUriTests.cs
+++ b/web-api/tests/Kerbero.Domain.Tests/NukiCredentials/Interactors/BuildNukiRedirectUriTests.cs
@@ -1,0 +1,47 @@
+using System.Web;
+using FluentAssertions;
+using FluentResults;
+using Kerbero.Domain.Common.Repositories;
+using Kerbero.Domain.NukiCredentials.Interactors;
+using Kerbero.Domain.NukiCredentials.Models;
+using Moq;
+
+namespace Kerbero.Domain.Tests.NukiCredentials.Interactors;
+
+public class BuildNukiRedirectUriTests
+{
+  private readonly BuildNukiRedirectUriInteractor _interactor;
+  private readonly Mock<IKerberoConfigurationRepository> _kerberoConfigurationRepositoryMock = new();
+
+  public BuildNukiRedirectUriTests()
+  {
+    _interactor = new BuildNukiRedirectUriInteractor(_kerberoConfigurationRepositoryMock.Object);
+  }
+
+  [Fact]
+  async Task It_Creates_A_Correct_Uri()
+  {
+    var model = new NukiApiConfigurationModel(
+      ApiEndpoint: "https://api.nuki.io",
+      ClientId: "0",
+      Scopes: "account notification",
+      ApplicationDomain: "https://test.domain",
+      ApplicationRedirectEndpoint: "api/nuki-credentials/confirm-draft"
+    );
+
+    _kerberoConfigurationRepositoryMock
+      .Setup(repo => repo.GetNukiApiDefinition())
+      .ReturnsAsync(() => Result.Ok(model));
+
+    var uriResult = await _interactor.Handle();
+
+    var baseNukiApiEndpoint = "https://api.nuki.io/oauth/authorize";
+    var redirectUri = $"redirect_uri={HttpUtility.UrlEncode("https://test.domain/api/nuki-credentials/confirm-draft")}";
+    var nukiScopes = $"scope={HttpUtility.UrlEncode("account notification")}";
+    var responseTypeAndClient = "response_type=code&client_id=0";
+    var expectedUri = $"{baseNukiApiEndpoint}?{responseTypeAndClient}&{nukiScopes}&{redirectUri}";
+
+    uriResult.IsSuccess.Should().BeTrue();
+    uriResult.Value.ToString().Should().MatchEquivalentOf(expectedUri);
+  }
+}


### PR DESCRIPTION
```csharp
async Task Example(IKerberoConfigurationRepository kerberoConf){
  var interactor = new BuildNukiRedirectUriInteractor(kerberoConf);
  
  var uriResult = await interactor.Handle();
  
  // uriResult.Value example
  // https://api.nuki.io/oauth/authorize?response_type=code&client_id=0&scope=account+notification&redirect_uri=https%3a%2f%2ftest.domain%2fapi%2fnuki-credentials%2fconfirm-draft
}
```