### PR TITLE
feat: create nuki draft credential interactor

### DIFF
--- a/web-api/src/Kerbero.Domain/NukiCredentials/Interactors/CreateNukiCredentialDraftInteractor.cs
+++ b/web-api/src/Kerbero.Domain/NukiCredentials/Interactors/CreateNukiCredentialDraftInteractor.cs
@@ -1,0 +1,40 @@
+using FluentResults;
+using Kerbero.Domain.NukiCredentials.Interfaces;
+using Kerbero.Domain.NukiCredentials.Models;
+using Kerbero.Domain.NukiCredentials.Repositories;
+
+namespace Kerbero.Domain.NukiCredentials.Interactors;
+
+/// <summary>
+/// Nuki Web platform authentication flow:
+/// Kerbero User, authenticated on Kerbero
+/// -> Redirect to Nuki website
+/// -> User accepts / allows Kerbero Nuki app to act in his behalf
+/// -> Nuki  website calls Kerbero API
+/// -> User comes back to kerbero with a lax cookie
+///
+/// Nuki Web redirect uri is driven by (<see cref="BuildNukiRedirectUriInteractor"/>
+/// </summary>
+public class CreateNukiCredentialDraftInteractor : ICreateNukiCredentialDraftInteractor
+{
+  private readonly INukiCredentialRepository _nukiCredentialRepository;
+
+  public CreateNukiCredentialDraftInteractor(INukiCredentialRepository nukiCredentialRepository)
+  {
+    _nukiCredentialRepository = nukiCredentialRepository;
+  }
+
+  public async Task<Result<NukiCredentialDraftModel>> Handle(Guid userId)
+  {
+    var nukiCredentialDraft = new NukiCredentialDraftModel(UserId: userId);
+
+    var createResult = await _nukiCredentialRepository.CreateDraft(nukiCredentialDraft);
+
+    if (createResult.IsFailed)
+    {
+      return Result.Fail(createResult.Errors);
+    }
+
+    return nukiCredentialDraft;
+  }
+}

--- a/web-api/src/Kerbero.Domain/NukiCredentials/Interfaces/ICreateNukiCredentialDraftInteractor.cs
+++ b/web-api/src/Kerbero.Domain/NukiCredentials/Interfaces/ICreateNukiCredentialDraftInteractor.cs
@@ -1,0 +1,9 @@
+using FluentResults;
+using Kerbero.Domain.NukiCredentials.Models;
+
+namespace Kerbero.Domain.NukiCredentials.Interfaces;
+
+public interface ICreateNukiCredentialDraftInteractor
+{
+  Task<Result<NukiCredentialDraftModel>> Handle(Guid userId);
+}

--- a/web-api/src/Kerbero.Domain/NukiCredentials/Models/NukiCredentialDraftModel.cs
+++ b/web-api/src/Kerbero.Domain/NukiCredentials/Models/NukiCredentialDraftModel.cs
@@ -1,0 +1,8 @@
+namespace Kerbero.Domain.NukiCredentials.Models;
+
+/// <summary>
+/// Represents a nuki credential that will be confirmed later on after a Nuki Authentication process
+/// </summary>
+public record NukiCredentialDraftModel(Guid UserId, int? Id = null)
+{
+}

--- a/web-api/src/Kerbero.Domain/NukiCredentials/Repositories/INukiCredentialRepository.cs
+++ b/web-api/src/Kerbero.Domain/NukiCredentials/Repositories/INukiCredentialRepository.cs
@@ -9,4 +9,6 @@ public interface INukiCredentialRepository
   Task<Result<NukiCredentialModel>> GetById(int id);
   Task<Result<List<NukiCredentialModel>>> GetAllByUserId(Guid userId);
   Task<Result> ValidateApiToken(string apiToken);
+  
+  Task<Result<NukiCredentialModel>> CreateDraft(NukiCredentialDraftModel model);
 }

--- a/web-api/src/Kerbero.Infrastructure/NukiCredentials/Repositories/NukiCredentialRepository.cs
+++ b/web-api/src/Kerbero.Infrastructure/NukiCredentials/Repositories/NukiCredentialRepository.cs
@@ -147,4 +147,9 @@ public class NukiCredentialRepository : INukiCredentialRepository
 
     return Result.Ok();
   }
+
+  public Task<Result<NukiCredentialModel>> CreateDraft(NukiCredentialDraftModel model)
+  {
+    throw new NotImplementedException();
+  }
 }

--- a/web-api/tests/Kerbero.Domain.Tests/NukiCredentials/Interactors/BuildNukiRedirectUriInteractorTests.cs
+++ b/web-api/tests/Kerbero.Domain.Tests/NukiCredentials/Interactors/BuildNukiRedirectUriInteractorTests.cs
@@ -8,12 +8,12 @@ using Moq;
 
 namespace Kerbero.Domain.Tests.NukiCredentials.Interactors;
 
-public class BuildNukiRedirectUriTests
+public class BuildNukiRedirectUriInteractorTests
 {
   private readonly BuildNukiRedirectUriInteractor _interactor;
   private readonly Mock<IKerberoConfigurationRepository> _kerberoConfigurationRepositoryMock = new();
 
-  public BuildNukiRedirectUriTests()
+  public BuildNukiRedirectUriInteractorTests()
   {
     _interactor = new BuildNukiRedirectUriInteractor(_kerberoConfigurationRepositoryMock.Object);
   }

--- a/web-api/tests/Kerbero.Domain.Tests/NukiCredentials/Interactors/CreateNukiCredentialDraftInteractorTests.cs
+++ b/web-api/tests/Kerbero.Domain.Tests/NukiCredentials/Interactors/CreateNukiCredentialDraftInteractorTests.cs
@@ -1,0 +1,34 @@
+using FluentAssertions;
+using FluentResults;
+using Kerbero.Domain.NukiCredentials.Interactors;
+using Kerbero.Domain.NukiCredentials.Models;
+using Kerbero.Domain.NukiCredentials.Repositories;
+using Moq;
+
+namespace Kerbero.Domain.Tests.NukiCredentials.Interactors;
+
+public class CreateNukiCredentialDraftInteractorTests
+{
+  private readonly CreateNukiCredentialDraftInteractor _interactor;
+  private readonly Mock<INukiCredentialRepository> _nukiCredentialRepositoryMock = new();
+
+  public CreateNukiCredentialDraftInteractorTests()
+  {
+    _interactor = new CreateNukiCredentialDraftInteractor(_nukiCredentialRepositoryMock.Object);
+  }
+
+  [Fact]
+  async Task It_Stores_A_Draft_Credential()
+  {
+    var userId = Guid.NewGuid();
+    var model = new NukiCredentialDraftModel(UserId: userId);
+    _nukiCredentialRepositoryMock
+      .Setup(repo => repo.CreateDraft(It.IsAny<NukiCredentialDraftModel>()))
+      .ReturnsAsync(Result.Ok());
+
+    var result = await _interactor.Handle(userId);
+
+    _nukiCredentialRepositoryMock.Verify();
+    result.IsSuccess.Should().BeTrue();
+  }
+}


### PR DESCRIPTION
This is bringing back the ability to store a draft nuki credentials in order to support Nuki oauth flow (allows kerbero user to pair his Nuki account)

```csharp
async Task Test(INukiCredentialRepository repo) {
    var interactor = new CreateNukiCredentialDraftInteractor(repo);
    
    var userId = Guid.NewGuid();
    var model = new NukiCredentialDraftModel(UserId: userId);
    
    var result = await _interactor.Handle(userId);
    
    // result.IsSuccess -> true
}
```