### PR TITLE
feat: confirm nuki draft credential interactor

### DIFF
--- a/web-api/src/Kerbero.Domain/NukiCredentials/Interactors/ConfirmNukiDraftCredentialsInteractor.cs
+++ b/web-api/src/Kerbero.Domain/NukiCredentials/Interactors/ConfirmNukiDraftCredentialsInteractor.cs
@@ -1,0 +1,58 @@
+using FluentResults;
+using Kerbero.Domain.Common.Repositories;
+using Kerbero.Domain.NukiCredentials.Interfaces;
+using Kerbero.Domain.NukiCredentials.Models;
+using Kerbero.Domain.NukiCredentials.Repositories;
+
+namespace Kerbero.Domain.NukiCredentials.Interactors;
+
+public class ConfirmNukiDraftCredentialsInteractor : IConfirmNukiDraftCredentialsInteractor
+{
+  private readonly INukiCredentialRepository _nukiCredentialRepository;
+  private readonly IKerberoConfigurationRepository _kerberoConfigurationRepository;
+
+
+  public ConfirmNukiDraftCredentialsInteractor(INukiCredentialRepository nukiCredentialRepository,
+    IKerberoConfigurationRepository kerberoConfigurationRepository)
+  {
+    _nukiCredentialRepository = nukiCredentialRepository;
+    _kerberoConfigurationRepository = kerberoConfigurationRepository;
+  }
+
+  public async Task<Result<NukiCredentialModel>> Handle(string code, Guid userId)
+  {
+    var buildNukiRedirectInteractor = new BuildNukiRedirectUriInteractor(_kerberoConfigurationRepository);
+    var redirectUriResult = await buildNukiRedirectInteractor.Handle();
+    
+    if (redirectUriResult.IsFailed)
+    {
+      return Result.Fail(redirectUriResult.Errors);
+    }
+
+    // Ensure we have the requested draft
+    var nukiCredentialDraftResult =
+      await _nukiCredentialRepository.GetDraftCredentialsByUserId(userId);
+
+    if (nukiCredentialDraftResult.IsFailed)
+    {
+      return Result.Fail(nukiCredentialDraftResult.Errors);
+    }
+
+    // Retrieve a token
+    var refreshableCredentialResult = await _nukiCredentialRepository.GetRefreshableCredential(code, redirectUriResult.Value.ToString());
+
+    // Confirm the draft
+    var nukiCredentialModelResult =
+      await _nukiCredentialRepository.ConfirmDraft(nukiCredentialDraftResult.Value, refreshableCredentialResult.Value);
+
+    if (nukiCredentialModelResult.IsFailed)
+    {
+      return nukiCredentialModelResult.ToResult();
+    }
+
+    // clear any pending draft
+    await _nukiCredentialRepository.DeleteDraftByUserId(userId);
+
+    return nukiCredentialModelResult.Value;
+  }
+}

--- a/web-api/src/Kerbero.Domain/NukiCredentials/Interfaces/IConfirmNukiDraftCredentialsInteractor.cs
+++ b/web-api/src/Kerbero.Domain/NukiCredentials/Interfaces/IConfirmNukiDraftCredentialsInteractor.cs
@@ -1,0 +1,9 @@
+using FluentResults;
+using Kerbero.Domain.NukiCredentials.Models;
+
+namespace Kerbero.Domain.NukiCredentials.Interfaces;
+
+public interface IConfirmNukiDraftCredentialsInteractor
+{
+  Task<Result<NukiCredentialModel>> Handle(string code, Guid userId);
+}

--- a/web-api/src/Kerbero.Domain/NukiCredentials/Models/NukiRefreshableCredentialModel.cs
+++ b/web-api/src/Kerbero.Domain/NukiCredentials/Models/NukiRefreshableCredentialModel.cs
@@ -1,0 +1,20 @@
+namespace Kerbero.Domain.NukiCredentials.Models;
+
+/// <summary>
+/// Credentials returned by Nuki rest api at the end of a Nuki oauth flow
+/// </summary>
+/// <param name="Token"></param>
+/// <param name="RefreshToken"></param>
+/// <param name="TokenExpiresIn"></param>
+/// <param name="Error"></param>
+/// <param name="CreatedAt"></param>
+public record NukiRefreshableCredentialModel
+(
+  string Token,
+  string RefreshToken,
+  int TokenExpiresIn,
+  string? Error,
+  DateTime CreatedAt
+)
+{
+}

--- a/web-api/src/Kerbero.Domain/NukiCredentials/Repositories/INukiCredentialRepository.cs
+++ b/web-api/src/Kerbero.Domain/NukiCredentials/Repositories/INukiCredentialRepository.cs
@@ -11,4 +11,12 @@ public interface INukiCredentialRepository
   Task<Result> ValidateApiToken(string apiToken);
   
   Task<Result<NukiCredentialModel>> CreateDraft(NukiCredentialDraftModel model);
+  
+  Task<Result<NukiCredentialDraftModel>> GetDraftCredentialsByUserId(Guid userId);
+  
+  Task<Result<NukiRefreshableCredentialModel>> GetRefreshableCredential(string oAuthCode, string redirectUri);
+  
+  Task<Result<NukiCredentialModel>> ConfirmDraft(NukiCredentialDraftModel draft, NukiRefreshableCredentialModel model);
+
+  Task<Result> DeleteDraftByUserId(Guid userId);
 }

--- a/web-api/src/Kerbero.Infrastructure/NukiCredentials/Repositories/NukiCredentialRepository.cs
+++ b/web-api/src/Kerbero.Infrastructure/NukiCredentials/Repositories/NukiCredentialRepository.cs
@@ -152,4 +152,25 @@ public class NukiCredentialRepository : INukiCredentialRepository
   {
     throw new NotImplementedException();
   }
+
+  public Task<Result<NukiCredentialDraftModel>> GetDraftCredentialsByUserId(Guid userId)
+  {
+    throw new NotImplementedException();
+  }
+
+  public Task<Result<NukiRefreshableCredentialModel>> GetRefreshableCredential(string oAuthCode, string redirectUri)
+  {
+    throw new NotImplementedException();
+  }
+
+  public Task<Result<NukiCredentialModel>> ConfirmDraft(NukiCredentialDraftModel draft,
+    NukiRefreshableCredentialModel model)
+  {
+    throw new NotImplementedException();
+  }
+
+  public Task<Result> DeleteDraftByUserId(Guid userId)
+  {
+    throw new NotImplementedException();
+  }
 }

--- a/web-api/tests/Kerbero.Domain.Tests/NukiCredentials/Interactors/ConfirmNukiDraftCredentialsInteractorTests.cs
+++ b/web-api/tests/Kerbero.Domain.Tests/NukiCredentials/Interactors/ConfirmNukiDraftCredentialsInteractorTests.cs
@@ -1,0 +1,86 @@
+using FluentAssertions;
+using FluentResults;
+using Kerbero.Domain.Common.Repositories;
+using Kerbero.Domain.NukiCredentials.Interactors;
+using Kerbero.Domain.NukiCredentials.Models;
+using Kerbero.Domain.NukiCredentials.Repositories;
+using Moq;
+
+namespace Kerbero.Domain.Tests.NukiCredentials.Interactors;
+
+public class ConfirmNukiDraftCredentialsInteractorTests
+{
+  private readonly ConfirmNukiDraftCredentialsInteractor _interactor;
+  private readonly Mock<IKerberoConfigurationRepository> _kerberoConfigurationRepositoryMock = new();
+  private readonly Mock<INukiCredentialRepository> _nukiCredentialRepositoryMock = new();
+
+  public ConfirmNukiDraftCredentialsInteractorTests()
+  {
+    _interactor = new ConfirmNukiDraftCredentialsInteractor(
+      kerberoConfigurationRepository: _kerberoConfigurationRepositoryMock.Object,
+      nukiCredentialRepository: _nukiCredentialRepositoryMock.Object
+    );
+  }
+
+  [Fact]
+  async Task It_Confirms_A_Draft_Credential()
+  {
+    var userId = Guid.NewGuid();
+    var token = "A_TOKEN";
+    var configurationModel = new NukiApiConfigurationModel(
+      ApiEndpoint: "https://api.nuki.io",
+      ClientId: "0",
+      Scopes: "account notification",
+      ApplicationDomain: "https://test.domain",
+      ApplicationRedirectEndpoint: "api/nuki-credentials/confirm-draft"
+    );
+
+    var finalModel = new NukiCredentialModel()
+    {
+      Id = 0,
+      Token = token,
+      UserId = userId
+    };
+
+    var refreshModel = new NukiRefreshableCredentialModel(
+      Token: token,
+      RefreshToken: token,
+      TokenExpiresIn: 27900,
+      Error: null,
+      CreatedAt: DateTime.Now
+    );
+
+    var draftModel = new NukiCredentialDraftModel(
+      UserId: userId,
+      Id: 0
+    );
+
+    _kerberoConfigurationRepositoryMock
+      .Setup(repo => repo.GetNukiApiDefinition())
+      .ReturnsAsync(() => Result.Ok(configurationModel));
+
+    _nukiCredentialRepositoryMock
+      .Setup(repo => repo.GetDraftCredentialsByUserId(It.IsAny<Guid>()))
+      .ReturnsAsync(Result.Ok(draftModel));
+
+    _nukiCredentialRepositoryMock
+      .Setup(repo => repo.GetRefreshableCredential(It.IsAny<string>(), It.IsAny<string>()))
+      .ReturnsAsync(Result.Ok(refreshModel));
+
+    _nukiCredentialRepositoryMock
+      .Setup(repo =>
+        repo.ConfirmDraft(It.IsAny<NukiCredentialDraftModel>(), It.IsAny<NukiRefreshableCredentialModel>()))
+      .ReturnsAsync(Result.Ok(finalModel));
+
+    _nukiCredentialRepositoryMock
+      .Setup(repo => repo.DeleteDraftByUserId(It.IsAny<Guid>()))
+      .ReturnsAsync(Result.Ok);
+
+    var result = await _interactor.Handle("acode", userId);
+
+    _kerberoConfigurationRepositoryMock.Verify();
+    _nukiCredentialRepositoryMock.Verify();
+    result.IsSuccess.Should().BeTrue();
+    result.Value.Should().BeEquivalentTo(finalModel);
+  }
+}


### PR DESCRIPTION
Final interactor for the nuki oauth flow management.
Confirms a pending draft credential and cleans up any draft associated to a given user

```csharp
async Tast Test(INukiCredentialRepository nukiCredentialRepo, IKerberoConfigurationRepository configRepo) 
{
    var interactor = new new ConfirmNukiDraftCredentialsInteractor(
      kerberoConfigurationRepository: configRepo,
      nukiCredentialRepository: nukiCredentialRepo
    );
    
    var result = await _interactor.Handle("acode", userId);
    
    // result will be a nuki credential with a working token
}
```