### PR TITLE
Fix integration test application initialization

### DIFF
--- a/web-api/tests/Kerbero.Integration.Tests/KerberoWebApplicationFactory.cs
+++ b/web-api/tests/Kerbero.Integration.Tests/KerberoWebApplicationFactory.cs
@@ -31,6 +31,7 @@ public class KerberoWebApplicationFactory<TStartup>
     _connection = new SqliteConnection(_config["SQLITE_CONNECTION_STRING"]);
     _connection.Open();
     ClientOptions.AllowAutoRedirect = false;
+    Server.PreserveExecutionContext = true; // Flurl fixture: https://github.com/tmenier/Flurl/issues/645
   }
 
   protected override void ConfigureWebHost(IWebHostBuilder builder)

--- a/web-api/tests/Kerbero.Integration.Tests/NukiCredentials/NukiAuthenticationIntegrationTests.cs
+++ b/web-api/tests/Kerbero.Integration.Tests/NukiCredentials/NukiAuthenticationIntegrationTests.cs
@@ -14,7 +14,6 @@ public class NukiCredentialsIntegrationTests
   public NukiCredentialsIntegrationTests()
   {
     _application = new KerberoWebApplicationFactory<Program>();
-    _application.Server.PreserveExecutionContext = true; // fixture for Flurl
   }
 
   [Fact]

--- a/web-api/tests/Kerbero.Integration.Tests/SmartLockKeys/CloseSmartLockWithKeyIntegrationTests.cs
+++ b/web-api/tests/Kerbero.Integration.Tests/SmartLockKeys/CloseSmartLockWithKeyIntegrationTests.cs
@@ -15,7 +15,6 @@ public class CloseSmartLockWithKeyIntegrationTests : IDisposable
   public CloseSmartLockWithKeyIntegrationTests()
   {
     _application = new KerberoWebApplicationFactory<Program>();
-    _application.Server.PreserveExecutionContext = true; // fixture for Flurl
     _httpTest = new HttpTest();
   }
 

--- a/web-api/tests/Kerbero.Integration.Tests/SmartLockKeys/CreateSmartLockKeyIntegrationTests.cs
+++ b/web-api/tests/Kerbero.Integration.Tests/SmartLockKeys/CreateSmartLockKeyIntegrationTests.cs
@@ -15,7 +15,6 @@ public class CreateSmartLockKeyIntegrationTests : IDisposable
   public CreateSmartLockKeyIntegrationTests()
   {
     _application = new KerberoWebApplicationFactory<Program>();
-    _application.Server.PreserveExecutionContext = true; // fixture for Flurl
     _httpTest = new HttpTest();
   }
 

--- a/web-api/tests/Kerbero.Integration.Tests/SmartLockKeys/DeleteSmartLockKeyIntegrationTests.cs
+++ b/web-api/tests/Kerbero.Integration.Tests/SmartLockKeys/DeleteSmartLockKeyIntegrationTests.cs
@@ -15,7 +15,6 @@ public class DeleteSmartLockKeyIntegrationTests : IDisposable
   public DeleteSmartLockKeyIntegrationTests()
   {
     _application = new KerberoWebApplicationFactory<Program>();
-    _application.Server.PreserveExecutionContext = true; // fixture for Flurl
     _httpTest = new HttpTest();
   }
 

--- a/web-api/tests/Kerbero.Integration.Tests/SmartLockKeys/GetSmartLockKeysIntegrationTests.cs
+++ b/web-api/tests/Kerbero.Integration.Tests/SmartLockKeys/GetSmartLockKeysIntegrationTests.cs
@@ -15,7 +15,6 @@ public class GetSmartLockKeysIntegrationTests : IDisposable
   public GetSmartLockKeysIntegrationTests()
   {
     _application = new KerberoWebApplicationFactory<Program>();
-    _application.Server.PreserveExecutionContext = true; // fixture for Flurl
     _httpTest = new HttpTest();
   }
 

--- a/web-api/tests/Kerbero.Integration.Tests/SmartLockKeys/OpenSmartLockWithKeyIntegrationTests.cs
+++ b/web-api/tests/Kerbero.Integration.Tests/SmartLockKeys/OpenSmartLockWithKeyIntegrationTests.cs
@@ -15,7 +15,6 @@ public class OpenSmartLockWithKeyIntegrationTests : IDisposable
   public OpenSmartLockWithKeyIntegrationTests()
   {
     _application = new KerberoWebApplicationFactory<Program>();
-    _application.Server.PreserveExecutionContext = true; // fixture for Flurl
     _httpTest = new HttpTest();
   }
 

--- a/web-api/tests/Kerbero.Integration.Tests/SmartLockKeys/UpdateSmartLockKeyValidityIntegrationTests.cs
+++ b/web-api/tests/Kerbero.Integration.Tests/SmartLockKeys/UpdateSmartLockKeyValidityIntegrationTests.cs
@@ -13,7 +13,6 @@ public class UpdateSmartLockKeyValidityIntegrationTests
   public UpdateSmartLockKeyValidityIntegrationTests()
   {
     _application = new KerberoWebApplicationFactory<Program>();
-    _application.Server.PreserveExecutionContext = true; // fixture for Flurl
   }
 
   [Fact]

--- a/web-api/tests/Kerbero.Integration.Tests/SmartLocks/SmartLockIntegrationTests.cs
+++ b/web-api/tests/Kerbero.Integration.Tests/SmartLocks/SmartLockIntegrationTests.cs
@@ -17,7 +17,6 @@ public class SmartLockIntegrationTests
   {
     _httpTest = new HttpTest();
     _application = new KerberoWebApplicationFactory<Program>();
-    _application.Server.PreserveExecutionContext = true; // fixture for Flurl
   }
 
   [Fact]


### PR DESCRIPTION
Moved "PreserveExecutionContext = true" to integration test application constructor.