### PR TITLE
Improved and fixed oauth authentication to nuki web apis

### DIFF
--- a/web-api/src/Kerbero.Data/Common/Repositories/KerberoConfigurationRepository.cs
+++ b/web-api/src/Kerbero.Data/Common/Repositories/KerberoConfigurationRepository.cs
@@ -21,7 +21,10 @@ public class KerberoConfigurationRepository : IKerberoConfigurationRepository
       ClientId: _configuration["NUKI_CLIENT_ID"]!,
       Scopes: _configuration["NUKI_SCOPES"]!,
       ApplicationRedirectEndpoint: _configuration["NUKI_REDIRECT_FOR_TOKEN"]!,
-      ApplicationDomain: _configuration["ALIAS_DOMAIN"]!
+      ApplicationDomain: _configuration["ALIAS_DOMAIN"]!,
+      WebAppDomain: _configuration["WEB_APP_DOMAIN"]!,
+      WebAppSuccessRedirectEndpoint: _configuration["NUKI_REDIRECT_FOR_SUCCESS"]!,
+      WebAppFailureRedirectEndpoint: _configuration["NUKI_REDIRECT_FOR_FAILURE"]!
     ));
   }
 }

--- a/web-api/src/Kerbero.Data/Migrations/20221214145728_Init.Designer.cs
+++ b/web-api/src/Kerbero.Data/Migrations/20221214145728_Init.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Kerbero.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20221205144615_Init")]
+    [Migration("20221214145728_Init")]
     partial class Init
     {
         /// <inheritdoc />
@@ -46,7 +46,6 @@ namespace Kerbero.Data.Migrations
                         .HasColumnType("boolean");
 
                     b.Property<string>("NukiEmail")
-                        .IsRequired()
                         .HasColumnType("text");
 
                     b.Property<string>("RefreshToken")

--- a/web-api/src/Kerbero.Data/Migrations/20221214145728_Init.cs
+++ b/web-api/src/Kerbero.Data/Migrations/20221214145728_Init.cs
@@ -192,7 +192,7 @@ namespace Kerbero.Data.Migrations
                     ExpiresIn = table.Column<int>(type: "integer", nullable: true),
                     CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
                     UserId = table.Column<Guid>(type: "uuid", nullable: false),
-                    NukiEmail = table.Column<string>(type: "text", nullable: false)
+                    NukiEmail = table.Column<string>(type: "text", nullable: true)
                 },
                 constraints: table =>
                 {

--- a/web-api/src/Kerbero.Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/web-api/src/Kerbero.Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -43,7 +43,6 @@ namespace Kerbero.Data.Migrations
                         .HasColumnType("boolean");
 
                     b.Property<string>("NukiEmail")
-                        .IsRequired()
                         .HasColumnType("text");
 
                     b.Property<string>("RefreshToken")

--- a/web-api/src/Kerbero.Data/NukiCredentials/Entities/NukiCredentialEntity.cs
+++ b/web-api/src/Kerbero.Data/NukiCredentials/Entities/NukiCredentialEntity.cs
@@ -26,5 +26,5 @@ public class NukiCredentialEntity
   [ForeignKey((nameof(UserId)))] public User? User { get; set; }
 
   // Email used by our user to signup into Nuki web services 
-  public string NukiEmail { get; set; } = null!;
+  public string? NukiEmail { get; set; }
 }

--- a/web-api/src/Kerbero.Data/NukiCredentials/Mappers/NukiCredentialMapper.cs
+++ b/web-api/src/Kerbero.Data/NukiCredentials/Mappers/NukiCredentialMapper.cs
@@ -13,7 +13,7 @@ public static class NukiCredentialMapper
       Id = entity.Id,
       Token = entity.Token,
       UserId = entity.UserId,
-      NukiEmail = entity.NukiEmail,
+      NukiEmail = entity.NukiEmail!,
       IsRefreshable = entity.IsRefreshable
     };
   }

--- a/web-api/src/Kerbero.Domain/NukiCredentials/Interactors/BuildNukiRedirectUriInteractor.cs
+++ b/web-api/src/Kerbero.Domain/NukiCredentials/Interactors/BuildNukiRedirectUriInteractor.cs
@@ -2,6 +2,7 @@ using System.Web;
 using FluentResults;
 using Kerbero.Domain.Common.Repositories;
 using Kerbero.Domain.NukiCredentials.Interfaces;
+using Kerbero.Domain.NukiCredentials.Utils;
 
 namespace Kerbero.Domain.NukiCredentials.Interactors;
 
@@ -29,8 +30,7 @@ public class BuildNukiRedirectUriInteractor : IBuildNukiRedirectUriInteractor
     var nukiApiDefinition = nukiApiDefinitionResult.Value;
 
     var baseUri = $"{nukiApiDefinition.ApiEndpoint}/oauth/authorize";
-    var applicationRedirectUri =
-      $"{nukiApiDefinition.ApplicationDomain}/{nukiApiDefinition.ApplicationRedirectEndpoint}";
+    var applicationRedirectUri = BuildRedirectToKerberoUriHelper.Handle(nukiApiDefinition);
 
     var queryParams = new List<string>()
     {

--- a/web-api/src/Kerbero.Domain/NukiCredentials/Interactors/BuildWebAppRedirectUriInteractor.cs
+++ b/web-api/src/Kerbero.Domain/NukiCredentials/Interactors/BuildWebAppRedirectUriInteractor.cs
@@ -1,0 +1,29 @@
+using FluentResults;
+using Kerbero.Domain.Common.Repositories;
+using Kerbero.Domain.NukiCredentials.Interfaces;
+
+namespace Kerbero.Domain.NukiCredentials.Interactors;
+
+public class BuildWebAppRedirectUriInteractor: IBuildWebAppRedirectUriInteractor
+{
+	private readonly IKerberoConfigurationRepository _kerberoConfigurationRepository;
+
+	public BuildWebAppRedirectUriInteractor(IKerberoConfigurationRepository kerberoConfigurationRepository)
+	{
+		_kerberoConfigurationRepository = kerberoConfigurationRepository;
+	}
+
+	public async Task<Result<Uri>> Handle(bool isSuccessUri)
+	{
+		var nukiApiDefinitionResult = await _kerberoConfigurationRepository.GetNukiApiDefinition();
+		if (nukiApiDefinitionResult.IsFailed)
+		{
+			return Result.Fail(nukiApiDefinitionResult.Errors);
+		}
+
+		var nukiApiDefinition = nukiApiDefinitionResult.Value;
+		var redirectToWebApp = isSuccessUri ? $"{nukiApiDefinition.WebAppDomain}/{nukiApiDefinition.WebAppSuccessRedirectEndpoint}"
+			: $"{nukiApiDefinition.WebAppDomain}/{nukiApiDefinition.WebAppFailureRedirectEndpoint}";
+		return new Uri(redirectToWebApp);
+	}
+}

--- a/web-api/src/Kerbero.Domain/NukiCredentials/Interfaces/IBuildWebAppRedirectUriInteractor.cs
+++ b/web-api/src/Kerbero.Domain/NukiCredentials/Interfaces/IBuildWebAppRedirectUriInteractor.cs
@@ -1,0 +1,8 @@
+using FluentResults;
+
+namespace Kerbero.Domain.NukiCredentials.Interfaces;
+
+public interface IBuildWebAppRedirectUriInteractor
+{
+	public Task<Result<Uri>> Handle(bool isSuccessUri);
+}

--- a/web-api/src/Kerbero.Domain/NukiCredentials/Models/NukiApiConfigurationModel.cs
+++ b/web-api/src/Kerbero.Domain/NukiCredentials/Models/NukiApiConfigurationModel.cs
@@ -13,5 +13,8 @@ public record NukiApiConfigurationModel(
   string ClientId,
   string Scopes,
   string ApplicationRedirectEndpoint,
-  string ApplicationDomain
+  string ApplicationDomain,
+  string WebAppDomain,
+  string WebAppSuccessRedirectEndpoint,
+  string WebAppFailureRedirectEndpoint
 );

--- a/web-api/src/Kerbero.Domain/NukiCredentials/Utils/BuildRedirectToKerberoUriHelper.cs
+++ b/web-api/src/Kerbero.Domain/NukiCredentials/Utils/BuildRedirectToKerberoUriHelper.cs
@@ -1,0 +1,11 @@
+using Kerbero.Domain.NukiCredentials.Models;
+
+namespace Kerbero.Domain.NukiCredentials.Utils;
+
+public static class BuildRedirectToKerberoUriHelper
+{
+	public static string Handle(NukiApiConfigurationModel nukiApiConfigurationModel)
+	{
+		return $"{nukiApiConfigurationModel.ApplicationDomain}/{nukiApiConfigurationModel.ApplicationRedirectEndpoint}";
+	}
+}

--- a/web-api/src/Kerbero.WebApi/.env-example
+++ b/web-api/src/Kerbero.WebApi/.env-example
@@ -1,12 +1,14 @@
 ### THIS .env is a placeholder of the original, copy this file inside the WebApi folder
 
+# Domain alias use in place of localhost
+ALIAS_DOMAIN="https://test.com:5220"
+
+# Web app domain
+WEB_APP_DOMAIN="https://test.com:5173"
+
 # Nuki API options
-
-ALIAS_DOMAIN=https://test.com:5220
-
-# Nuki API options
-
-NUKI_REDIRECT_FOR_TOKEN=/api/nuki/auth/token
+NUKI_REDIRECT_FOR_TOKEN=api/nuki-credentials/confirm-draft-hook
+NUKI_REDIRECT_FOR_SUCCESS=user
 NUKI_SCOPES="account notification smartlock smartlock.readOnly smartlock.action smartlock.auth smartlock.config smartlock.log"
 NUKI_DOMAIN=https://api.nuki.io
 NUKI_CLIENT_SECRET=NUKI_CLIENT_SECRET

--- a/web-api/src/Kerbero.WebApi/ConfigureService.cs
+++ b/web-api/src/Kerbero.WebApi/ConfigureService.cs
@@ -28,5 +28,6 @@ public static class ConfigureService
     services.AddScoped<IDeleteNukiCredentialInteractor, DeleteNukiCredentialInteractor>();
     services.AddScoped<IUpdateSmartLockKeyValidityInteractor, UpdateSmartLockKeyValidityInteractor>();
     services.AddScoped<IEnsureNukiCredentialBelongsToUserInteractor, EnsureNukiCredentialBelongsToUserInteractor>();
+    services.AddScoped<IBuildWebAppRedirectUriInteractor, BuildWebAppRedirectUriInteractor>();
   }
 }

--- a/web-api/src/Kerbero.WebApi/Program.cs
+++ b/web-api/src/Kerbero.WebApi/Program.cs
@@ -55,7 +55,7 @@ builder.Services.AddCors(options =>
 			.AllowAnyHeader()
 			.AllowAnyMethod()
 			.AllowAnyOrigin()
-			.WithOrigins("http://127.0.0.1:5173", "http://localhost:5173, https://127.0.0.1:5173", "https://localhost:5173"); /* TODO ADD PROD DOMAIN */
+			.WithOrigins("http://127.0.0.1:5173", "http://localhost:5173", "https://127.0.0.1:5173", "https://localhost:5173", "https://test.com:5173");
 	});
 });
 

--- a/web-api/tests/Kerbero.Domain.Tests/NukiCredentials/Interactors/BuildNukiRedirectUriInteractorTests.cs
+++ b/web-api/tests/Kerbero.Domain.Tests/NukiCredentials/Interactors/BuildNukiRedirectUriInteractorTests.cs
@@ -26,7 +26,10 @@ public class BuildNukiRedirectUriInteractorTests
       ClientId: "0",
       Scopes: "account notification",
       ApplicationDomain: "https://test.domain",
-      ApplicationRedirectEndpoint: "api/nuki-credentials/confirm-draft"
+      ApplicationRedirectEndpoint: "api/nuki-credentials/confirm-draft",
+      WebAppSuccessRedirectEndpoint: "user",
+      WebAppFailureRedirectEndpoint: "user/nuki-fail",
+      WebAppDomain: "https://test.webapp"
     );
 
     _kerberoConfigurationRepositoryMock

--- a/web-api/tests/Kerbero.Domain.Tests/NukiCredentials/Interactors/ConfirmNukiDraftCredentialsInteractorTests.cs
+++ b/web-api/tests/Kerbero.Domain.Tests/NukiCredentials/Interactors/ConfirmNukiDraftCredentialsInteractorTests.cs
@@ -32,7 +32,10 @@ public class ConfirmNukiDraftCredentialsInteractorTests
       ClientId: "0",
       Scopes: "account notification",
       ApplicationDomain: "https://test.domain",
-      ApplicationRedirectEndpoint: "api/nuki-credentials/confirm-draft"
+      ApplicationRedirectEndpoint: "api/nuki-credentials/confirm-draft",
+      WebAppSuccessRedirectEndpoint: "user",
+      WebAppFailureRedirectEndpoint: "user/nuki-fail",
+      WebAppDomain: "https://test.webapp"
     );
 
     var finalModel = new NukiCredentialModel()


### PR DESCRIPTION
- Fix: `NukiEmail` optional (if required cause problems in draft). New migrations.
- Fix: redirect uri on `oauth/token` call (must be the same of `oauth/code`).
- Fix: update `confirm-draft-hook` kerbero endpoint with new query parameter to check if it is the success case.
- Update the .env